### PR TITLE
URL should be escaped for shell

### DIFF
--- a/src/YoutubeDl.php
+++ b/src/YoutubeDl.php
@@ -168,7 +168,7 @@ class YoutubeDl
             $url = implode(' ', $url);
         }
 
-        $process = new Process(sprintf('%s %s', $this->getCommandLine(), $url), $this->downloadPath, null, null, $this->timeout, $this->processOptions);
+        $process = new Process(sprintf('%s %s', $this->getCommandLine(), escapeshellarg($url)), $this->downloadPath, null, null, $this->timeout, $this->processOptions);
 
         try {
             $process->mustRun(is_callable($this->debug) ? $this->debug : null);


### PR DESCRIPTION
Example:

```
$ youtube-dl --continue --format bestvideo --print-json --ignore-config https://www.youtube.com/watch?feature=player_embedded&v=HTLzK8eyZBA
```

> ERROR: Did you forget to quote the URL? Remember that & is a meta character in most shells, so you want to put the URL in quotes, like  youtube-dl "http://www.youtube.com/watch?feature=foo&v=BaW_jenozKc"  or simply  youtube-dl BaW_jenozKc .