### PR TITLE
Sometimes json_decode provides no error, so no exception thrown.

### DIFF
--- a/src/YoutubeDl.php
+++ b/src/YoutubeDl.php
@@ -193,13 +193,21 @@ class YoutubeDl
                 $videos = [];
 
                 foreach ($parts as $part) {
-                    $videos[] = $mapper->map($this->jsonDecode($part));
+                    $videoData = $this->jsonDecode($part);
+                    if (is_array($videoData)) {
+                        $videos[] = $mapper->map($videoData);
+                    }
                 }
 
                 return $videos;
             }
 
-            return $mapper->map($this->jsonDecode($parts[0]));
+            $videoData = $this->jsonDecode(reset($parts));
+            if (is_array($videoData)) {
+                return $mapper->map($videoData);
+            }
+            
+            return false;
         }
 
         return false;


### PR DESCRIPTION
Fix for: 

>Catchable fatal error: Argument 1 passed to YoutubeDl\Mapper\Mapper::map() must be of the type array, null given, called in /test/vendor/norkunas/youtube-dl-php/src/YoutubeDl.php on line 203 and defined in /test/vendor/norkunas/youtube-dl-php/src/Mapper/Mapper.php on line 43