### PR TITLE
Allow "output" option to contain folders

### DIFF
--- a/src/YoutubeDl.php
+++ b/src/YoutubeDl.php
@@ -192,10 +192,9 @@ class YoutubeDl
 
         if (!isset($this->options['skip-download']) || false === $this->options['skip-download']) {
             if (isset($this->options['extract-audio']) && true === $this->options['extract-audio']) {
-                $file = $this->findFile($videoData['_filename'], implode('|', $this->allowedAudioFormats));
-                $videoData['_filename'] = pathinfo($file, PATHINFO_BASENAME);
+                $videoData['_filename'] = $this->findFile($videoData['_filename'], implode('|', $this->allowedAudioFormats));
             } elseif (preg_match('/merged into mkv/', $process->getErrorOutput())) {
-                $videoData['_filename'] = pathinfo($this->findFile($videoData['_filename'], 'mkv'), PATHINFO_BASENAME);
+                $videoData['_filename'] = $this->findFile($videoData['_filename'], 'mkv');
             }
 
             $videoData['file'] = new \SplFileInfo($this->downloadPath.'/'.$videoData['_filename']);
@@ -249,10 +248,14 @@ class YoutubeDl
 
     private function findFile(string $fileName, string $extension)
     {
-        $iterator = new \RegexIterator(new \DirectoryIterator($this->downloadPath), sprintf('/%s\.%s$/ui', preg_quote(pathinfo($fileName, PATHINFO_FILENAME), '/'), '('.$extension.')'), \RegexIterator::GET_MATCH);
+        $dirName = pathinfo($fileName, PATHINFO_DIRNAME);
+        $path = $this->downloadPath.(('.' === $dirName) ? '' : DIRECTORY_SEPARATOR.$dirName);
+
+        $iterator = new \RegexIterator(new \DirectoryIterator($path), sprintf('/%s\.%s$/ui', preg_quote(pathinfo($fileName, PATHINFO_FILENAME), '/'), '('.$extension.')'), \RegexIterator::GET_MATCH);
+
         $iterator->rewind();
 
-        return $iterator->current()[0];
+        return (('.' === $dirName) ? '' : $dirName.DIRECTORY_SEPARATOR).$iterator->current()[0];
     }
 
     private function configureOptions(OptionsResolver $resolver)


### PR DESCRIPTION
I wanted to save the downloaded file into a folder that would be named according to the video's metadata. So I changed my code to this :

```
$dl = new YoutubeDl([
                                                    // ↶ THE SLASH HERE IS KEY!
    'output' => '%(id)s (%(uploader)s, %(upload_date)s)/%(title)s.%(ext)s',
    // ... more options ...
]);
$dl->setDownloadPath('downloads');
$dl->download('https://www.youtube.com/watch?v=JfgI3TB2MKs');
```

So here if I execute my script I will have the resulting tree in `downloads/` :

```
.
├── JfgI3TB2MKs (Igor Presnyakov, 20130530)
│   └── Hеrе Withоut Yоu - Igor Presnyakov - acoustic guitar.mp3
```

Without this code modification, it fails with the following error, as findFile was unable to find a file as it was looking in `$this->downloadPath` (and without recursion; I tried a first fix using recursion but it wasn't any better, as I had to modify the return value anyway) : 

```
PHP Fatal error:  Uncaught TypeError: pathinfo() expects parameter 1 to be string, null given in /vendor/norkunas/youtube-dl-php/src/YoutubeDl.php:196
Stack trace:
#0 /vendor/norkunas/youtube-dl-php/src/YoutubeDl.php(196): pathinfo(NULL, 2)
#1 /vendor/norkunas/youtube-dl-php/src/YoutubeDl.php(159): YoutubeDl\YoutubeDl->processDownload(Object(Symfony\Component\Process\Process))
```