### PR TITLE
Regex fix for matching m3u8 progress format

### DIFF
--- a/src/YoutubeDl.php
+++ b/src/YoutubeDl.php
@@ -20,7 +20,7 @@ use YoutubeDl\Exception\GeoBlockedException;
 
 class YoutubeDl
 {
-    const PROGRESS_PATTERN = '#\[download\]\s+(?<percentage>\d+(?:\.\d+)?%)\s+of\s+(?<size>\d+(?:\.\d+)?(?:K|M|G)iB)(?:\s+at\s+(?<speed>\d+(?:\.\d+)?(?:K|M|G)iB/s))?(?:\s+ETA\s+(?<eta>[\d:]{2,8}))#i';
+    const PROGRESS_PATTERN = '#\[download\]\s+(?<percentage>\d+(?:\.\d+)?%)\s+of\s+[~]?(?<size>\d+(?:\.\d+)?(?:K|M|G)iB)(?:\s+at\s+(?<speed>\d+(?:\.\d+)?(?:K|M|G)iB/s))?(?:\s+ETA\s+(?<eta>[\d:]{2,8}))#i';
 
     const RECODE_VIDEO_FORMATS = ['mp4', 'flv', 'ogg', 'webm', 'mkv', 'avi'];
 


### PR DESCRIPTION
sample progress format:
[download]  74.0% of ~59.44MiB at  9.37MiB/s ETA 00:03