### PR TITLE
Added symfony v5 as allowable version for composer deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
     "require": {
         "php": ">=7.0.8",
         "ext-json": "*",
-        "symfony/options-resolver": "^3.3|^4.0",
-        "symfony/process": "^3.3|^4.0"
+        "symfony/options-resolver": "^3.3|^4.0|^5.0",
+        "symfony/process": "^3.3|^4.0|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5"


### PR DESCRIPTION
Tests still pass - so a minor change I hope. Laravel v7 uses symfony v5 components which is why I noticed and bumped the version.

P.S Thanks for this package btw - it saved me a whole lot of work!
