### PR TITLE
Fix typo in "Format::getFormatId" for #115

### DIFF
--- a/src/Entity/Format.php
+++ b/src/Entity/Format.php
@@ -91,7 +91,7 @@ class Format extends AbstractEntity
      */
     public function getFormatId()
     {
-        return $this->get('format');
+        return $this->get('format_id');
     }
 
     /**


### PR DESCRIPTION
This fixes #115

With this change the result looks like this:
![image](https://user-images.githubusercontent.com/54676904/79425181-99902d80-7fc1-11ea-98e2-29e207b0347e.png)