### PR TITLE
Fixing download of age-gated videos.

### DIFF
--- a/src/YoutubeDl.php
+++ b/src/YoutubeDl.php
@@ -57,7 +57,7 @@ class YoutubeDl
     /**
      * @var array
      */
-    protected $allowedAudioFormats = ['best', 'aac', 'vorbis', 'mp3', 'm4a', 'opus', 'wav','flac'];
+    protected $allowedAudioFormats = ['best', 'aac', 'vorbis', 'mp3', 'm4a', 'opus', 'wav', 'flac'];
 
     /**
      * @var callable

--- a/src/YoutubeDl.php
+++ b/src/YoutubeDl.php
@@ -124,6 +124,7 @@ class YoutubeDl
             '--no-playlist',
             '--ignore-config',
             '--write-info-json',
+            '--rm-cache-dir',
         ];
 
         foreach ($this->options as $option => $value) {

--- a/src/YoutubeDl.php
+++ b/src/YoutubeDl.php
@@ -57,7 +57,7 @@ class YoutubeDl
     /**
      * @var array
      */
-    protected $allowedAudioFormats = ['best', 'aac', 'vorbis', 'mp3', 'm4a', 'opus', 'wav'];
+    protected $allowedAudioFormats = ['best', 'aac', 'vorbis', 'mp3', 'm4a', 'opus', 'wav','flac'];
 
     /**
      * @var callable

--- a/src/YoutubeDl.php
+++ b/src/YoutubeDl.php
@@ -187,7 +187,7 @@ class YoutubeDl
             throw new YoutubeDlException('Failed to detect metadata file.');
         }
 
-        $metadataFile = $this->downloadPath.'/'.$m[1];
+        $metadataFile = $this->downloadPath.DIRECTORY_SEPARATOR.basename($m[1]);
 
         $videoData = $this->jsonDecode(trim(file_get_contents($metadataFile)));
 
@@ -204,7 +204,7 @@ class YoutubeDl
                 $videoData['_filename'] = pathinfo($this->findFile($videoData['_filename'], 'mkv'), PATHINFO_BASENAME);
             }
 
-            $videoData['file'] = new \SplFileInfo($this->downloadPath.'/'.$videoData['_filename']);
+            $videoData['file'] = new \SplFileInfo($this->downloadPath.DIRECTORY_SEPARATOR.$videoData['_filename']);
         } else {
             $videoData['file'] = null;
         }
@@ -257,7 +257,7 @@ class YoutubeDl
 
     protected function findFile(string $fileName, string $extension)
     {
-        $iterator = new \RegexIterator(new \DirectoryIterator($this->downloadPath), sprintf('/%s\.%s$/ui', preg_quote(pathinfo($fileName, PATHINFO_FILENAME), '/'), '('.$extension.')'), \RegexIterator::GET_MATCH);
+        $iterator = new \RegexIterator(new \DirectoryIterator($this->downloadPath), sprintf('/%s\.%s$/ui', preg_quote(pathinfo($fileName, PATHINFO_FILENAME), DIRECTORY_SEPARATOR), '('.$extension.')'), \RegexIterator::GET_MATCH);
         $iterator->rewind();
 
         return $iterator->current()[0];

--- a/tests/YoutubeDl/YoutubeDlTest.php
+++ b/tests/YoutubeDl/YoutubeDlTest.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace YoutubeDl\Tests;
 
 use PHPUnit\Framework\TestCase;
+use YoutubeDl\Exception\UrlNotSupportedException;
 use YoutubeDl\YoutubeDl;
 
 class YoutubeDlTest extends TestCase
 {
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage No download path was set.
-     */
     public function testDownloadPathNotSet()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('No download path was set.');
+
         (new YoutubeDl())->download('');
     }
 
@@ -31,12 +31,11 @@ class YoutubeDlTest extends TestCase
         $this->assertGreaterThanOrEqual(1, $yt->getExtractorsList());
     }
 
-    /**
-     * @expectedException \YoutubeDl\Exception\UrlNotSupportedException
-     * @expectedExceptionMessageRegExp /Provided url '.+' is not supported\./
-     */
     public function testUrlNotSupported()
     {
+        $this->expectException(UrlNotSupportedException::class);
+        $this->expectExceptionMessageRegExp('/Provided url \'.+\' is not supported\./');
+
         $yt = new YoutubeDl();
         $yt->setDownloadPath('/');
         $yt->download('https://soundcloud.com/csimpi/sets/go4it-demo');


### PR DESCRIPTION
Fixing download of age-gated videos, the issue happened from the beginning of March 2020. It is a youtube-dl issue and the solution is by passing --rm-cache-dir flag to the download process. 

https://github.com/ytdl-org/youtube-dl/issues/24361