### PR TITLE
Add support for WARNING messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ $collection = $yt->download(
 );
 
 foreach ($collection->getVideos() as $video) {
+	if (!empty($video->getWarning())) {
+		foreach ($video->getWarning() as $warning) {
+			echo "Warning: {$warning}." . PHP_EOL;
+		}
+	}
     if ($video->getError() !== null) {
         echo "Error downloading video: {$video->getError()}.";
     } else {

--- a/src/Entity/Video.php
+++ b/src/Entity/Video.php
@@ -26,7 +26,7 @@ class Video extends AbstractEntity
         'thumbnails' => Thumbnail::class,
     ];
 
-    public function getWarning(): ?string
+    public function getWarning(): ?array
     {
         return $this->get('warning');
     }

--- a/src/Entity/Video.php
+++ b/src/Entity/Video.php
@@ -26,6 +26,11 @@ class Video extends AbstractEntity
         'thumbnails' => Thumbnail::class,
     ];
 
+    public function getWarning(): ?string
+    {
+        return $this->get('warning');
+    }
+
     public function getError(): ?string
     {
         return $this->get('error');

--- a/src/YoutubeDl.php
+++ b/src/YoutubeDl.php
@@ -157,7 +157,7 @@ class YoutubeDl
                     'error' => $parsedRow['error'] ?? null,
                     'warning' => $parsedRow['warning'] ?? [],
                     'extractor' => $parsedRow['extractor'] ?? 'generic',
-                    ]);
+                ]);
             } elseif (isset($parsedRow['metadataFile'])) {
                 $metadataFile = $parsedRow['metadataFile'];
                 $metadataFiles[] = $metadataFile;

--- a/src/YoutubeDl.php
+++ b/src/YoutubeDl.php
@@ -125,6 +125,8 @@ class YoutubeDl
                 $currentVideo['id'] = $match[2];
             } elseif (str_starts_with($buffer, 'ERROR:')) {
                 $currentVideo['error'] = trim(substr($buffer, 6));
+            } elseif (str_starts_with($buffer, 'WARNING:')) {
+                $currentVideo['warning'] = trim(substr($buffer, 8));
             } elseif (preg_match('/Writing video description metadata as JSON to:\s(.+)/', $buffer, $match) === 1) {
                 $currentVideo['metadataFile'] = $match[1];
             } elseif (preg_match('/\[ffmpeg] Merging formats into "(.+)"/', $buffer, $match) === 1) {
@@ -153,10 +155,14 @@ class YoutubeDl
 
         foreach ($parsedData as $parsedRow) {
             if (isset($parsedRow['error'])) {
-                $videos[] = new Video([
-                    'error' => $parsedRow['error'],
+                $params = [
                     'extractor' => $parsedRow['extractor'] ?? 'generic',
-                ]);
+                ];
+                if (isset($parsedRow['warning']))
+                   $params += ['warning' => $parsedRow['warning']];
+                if (isset($parsedRow['error']))
+                   $params += ['error' => $parsedRow['error']];
+                $videos[] = new Video($params);
             } elseif (isset($parsedRow['metadataFile'])) {
                 $metadataFile = $parsedRow['metadataFile'];
                 $metadataFiles[] = $metadataFile;

--- a/src/YoutubeDl.php
+++ b/src/YoutubeDl.php
@@ -130,7 +130,7 @@ class YoutubeDl
             } elseif (preg_match('/\[ffmpeg] Merging formats into "(.+)"/', $buffer, $match) === 1) {
                 $currentVideo['fileName'] = $match[1];
             } elseif (preg_match('/\[ffmpeg] Destination: (.+)/', $buffer, $match) === 1) {
-                $currentVideo['fileName'] = $match[1]; 
+                $currentVideo['fileName'] = $match[1];
             } elseif (preg_match('/\[download] Destination: (.+)/', $buffer, $match) === 1 || preg_match('/\[download] (.+) has already been downloaded/', $buffer, $match) === 1) {
                 $progressTarget = basename($match[1]);
             } elseif (preg_match_all(static::PROGRESS_PATTERN, $buffer, $matches, PREG_SET_ORDER) !== false) {

--- a/tests/Fixtures/fb/1582413528636185.txt
+++ b/tests/Fixtures/fb/1582413528636185.txt
@@ -1,0 +1,5 @@
+[facebook] Downloading login page
+[facebook] Logging in
+WARNING: unable to log in: bad username/password, or exceeded login rate limit (~3/min). Check credentials or wait.
+[facebook] 1582413528636185: Downloading webpage
+ERROR: This video is only available for registered users. Use --username and --password or --netrc to provide account credentials.


### PR DESCRIPTION
To test you can for example login with wrong credentials with Facebook.

```
...
	$collection = $yt->download($options);

	foreach ($collection->getVideos() as $video) {

		if ($video->getWarning() !== null) {
			http_response_code(415);
			echo "<pre>Warning downloading video: {$video->getWarning()}</pre>";
		}
		if ($video->getError() !== null) {
			http_response_code(415);
			echo "<pre>Error downloading video: {$video->getError()}</pre>";
			$success = false;
		}
...
```