### PR TITLE
Bugfix onProgress regex pattern trigger (~)

### DIFF
--- a/src/YoutubeDl.php
+++ b/src/YoutubeDl.php
@@ -36,7 +36,7 @@ use function trim;
 
 class YoutubeDl
 {
-    public const PROGRESS_PATTERN = '#\[download\]\s+(?<percentage>\d+(?:\.\d+)?%)\s+of\s+(?<size>[~]?\d+(?:\.\d+)?(?:K|M|G)iB)(?:\s+at\s+(?<speed>(\d+(?:\.\d+)?(?:K|M|G)iB/s)|Unknown speed))?(?:\s+ETA\s+(?<eta>([\d:]{2,8}|Unknown ETA)))?(\s+in\s+(?<totalTime>[\d:]{2,8}))?#i';
+    public const PROGRESS_PATTERN = '#\[download\]\s+(?<percentage>\d+(?:\.\d+)?%)\s+of\s+(?<size>[~]?[\s+]?\d+(?:\.\d+)?(?:K|M|G)iB)(?:\s+at\s+(?<speed>(\d+(?:\.\d+)?(?:K|M|G)iB/s)|Unknown speed))?(?:\s+ETA\s+(?<eta>([\d:]{2,8}|Unknown ETA)))?(\s+in\s+(?<totalTime>[\d:]{2,8}))?#';
 
     private ProcessBuilderInterface $processBuilder;
     private MetadataReaderInterface $metadataReader;


### PR DESCRIPTION
Fixed Download Progress event on yt-dlp v2023.03.04 

Before download info was:
[download]   0.1% of 820.00MiB at  599.88KiB/s ETA 23:18 (frag 0/82)

Now it prints as:
[download]   0.1% of ~ 820.00MiB at  599.88KiB/s ETA 23:18 (frag 0/82)