### PR TITLE
Updated list of recoding formats supported by YT-DLP

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -37,7 +37,7 @@ class Options
         self::AUDIO_FORMAT_ALAC,
     ];
 
-    public const RECODE_VIDEO_FORMATS = ['mp4', 'flv', 'ogg', 'webm', 'mkv', 'avi'];
+    public const RECODE_VIDEO_FORMATS = ['avi', 'flv', 'gif', 'mkv', 'mov', 'mp4', 'webm', 'aac', 'aiff', 'alac', 'flac', 'm4a', 'mka', 'mp3', 'ogg', 'opus', 'vorbis', 'wav'];
 
     public const SUBTITLE_FORMAT_SRT = 'srt';
     public const SUBTITLE_FORMAT_VTT = 'vtt';

--- a/src/Options.php
+++ b/src/Options.php
@@ -1375,10 +1375,10 @@ class Options
 
     /**
      * Remux the video into another container if necessary (currently supported:
-     * mp4|mkv|flv|webm|mov|avi|mp3|mka|m4a|ogg|opus). If target container does
-     * not support the video/audio codec, remuxing will fail. You can specify
-     * multiple rules; Eg. "aac>m4a/mov>mp4/mkv" will remux aac to * m4a,
-     * mov to mp4 and anything else to mkv.
+     * avi, flv, gif, mkv, mov, mp4, webm, aac, aiff, alac, flac, m4a, mka, mp3, ogg,
+     * opus, vorbis, wav). If target container does not support the video/audio codec,
+     * remuxing will fail. You can specify multiple rules; e.g. "aac>m4a/mov>mp4/mkv"
+     * will remux aac to m4a, mov to mp4 and anything else to mkv.
      */
     public function remuxVideo(?string $remuxVideo): self
     {

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -29,7 +29,7 @@ final class OptionsTest extends TestCase
     public function testInvalidRecodeVideoThrows(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Option `recodeVideo` expected one of: "mp4", "flv", "ogg", "webm", "mkv", "avi". Got: "mp4000".');
+        $this->expectExceptionMessage('Option `recodeVideo` expected one of: "avi", "flv", "gif", "mkv", "mov", "mp4", "webm", "aac", "aiff", "alac", "flac", "m4a", "mka", "mp3", "ogg", "opus", "vorbis", "wav". Got: "mp4000".');
 
         Options::create()->recodeVideo('mp4000');
     }


### PR DESCRIPTION
It's all in the title. The current list only seems to be about YouTube-DL and not YouTube-DLP. Here is the current list according to the YouTube-DL documentation: (https://github.com/ytdl-org/youtube-dl#post-processing-options)
```
--recode-video FORMAT                Encode the video to another format if
                                     necessary (currently supported:
                                     mp4|flv|ogg|webm|mkv|avi)
```
And here is the YouTube-DLP list: (https://github.com/yt-dlp/yt-dlp#post-processing-options)
```
--remux-video FORMAT            Remux the video into another container if
                                necessary (currently supported: avi, flv,
                                gif, mkv, mov, mp4, webm, aac, aiff, alac,
                                flac, m4a, mka, mp3, ogg, opus, vorbis,
                                wav). If target container does not support
                                the video/audio codec, remuxing will fail.
                                You can specify multiple rules; e.g.
                                "aac>m4a/mov>mp4/mkv" will remux aac to m4a,
                                mov to mp4 and anything else to mkv
--recode-video FORMAT           Re-encode the video into another format if
                                necessary. The syntax and supported formats
                                are the same as --remux-video
```