### PR TITLE
Fix returning array when provider does not support category retrieval

### DIFF
--- a/src/Entity/Video.php
+++ b/src/Entity/Video.php
@@ -456,7 +456,7 @@ class Video extends AbstractEntity
      */
     public function getCategories(): array
     {
-        return $this->get('categories');
+        return $this->get('categories', []);
     }
 
     /**


### PR DESCRIPTION
Fixing the issue #208 