### PR TITLE
Fix `Video::getDuration` typehint

### DIFF
--- a/src/Entity/Video.php
+++ b/src/Entity/Video.php
@@ -112,7 +112,7 @@ class Video extends AbstractEntity
         return $this->get('location');
     }
 
-    public function getDuration(): ?int
+    public function getDuration(): ?float
     {
         return $this->get('duration');
     }


### PR DESCRIPTION
Change Video::getDuration from int to float. 

Fix issue related facebook reels has duration is float.