### PR TITLE
Fix parsing without header

### DIFF
--- a/src/YoutubeDl.php
+++ b/src/YoutubeDl.php
@@ -252,7 +252,7 @@ class YoutubeDl
                 $parsing = 'subtitles';
             } elseif (str_contains($line, 'has no automatic captions') || str_contains($line, 'has no subtitles')) {
                 $parsing = null;
-            } elseif (str_contains($line, 'Language formats')) {
+            } elseif (str_contains($line, 'Language')) {
                 $header = $line;
             } elseif ($parsing !== null) {
                 if ($parsing === 'auto_caption') {


### PR DESCRIPTION
When using yt-dlp header coming empty since it can't enter elseif (str_contains($line, 'Language formats')) because that line changed to 'Language Name          formats' from  'Language formats'.