### PR TITLE
Add noHlsUseMpegts option to Options class

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -123,6 +123,7 @@ class Options
     private bool $hlsPreferNative = false;
     private bool $hlsPreferFFmpeg = false;
     private bool $hlsUseMpegts = false;
+    private bool $noHlsUseMpegts = false;
     private ?string $externalDownloader = null;
     private ?string $externalDownloaderArgs = null;
     private ?string $downloadSections = null;
@@ -770,6 +771,21 @@ class Options
     {
         $new = clone $this;
         $new->hlsUseMpegts = $hlsUseMpegts;
+
+        return $new;
+    }
+
+    /**
+     * Do not use the mpegts container for HLS videos.
+     * With this option, in the case of recording a live stream,
+     * the download will be written directly to an mp4 file.
+     * But without this option, the download will be written to a mpegts file
+     * and convert to mp4 file after the download is complete with +movflags +faststart.
+     */
+    public function noHlsUseMpegts(bool $noHlsUseMpegts): self
+    {
+        $new = clone $this;
+        $new->noHlsUseMpegts = $noHlsUseMpegts;
 
         return $new;
     }
@@ -1839,6 +1855,7 @@ class Options
             'hls-prefer-native' => $this->hlsPreferNative,
             'hls-prefer-ffmpeg' => $this->hlsPreferFFmpeg,
             'hls-use-mpegts' => $this->hlsUseMpegts,
+            'no-hls-use-mpegts' => $this->noHlsUseMpegts,
             'external-downloader' => $this->externalDownloader,
             'external-downloader-args' => $this->externalDownloaderArgs,
             'download-sections' => $this->downloadSections,


### PR DESCRIPTION
Introduced a new boolean property to prevent the use of the MPEG-TS container for live videos. This enables direct recording to an MP4 file without further conversions, which can significantly reduce hard drive IOPS.

By default, for live streams, yt-dlp writes to a MPEG-TS container and converts it to MP4 after the stream ends. Additionally, it adds hardcoded +movflags +faststart. As a result, this process uses approximately 3× the hard drive bandwidth: the TS-to-MP4 conversion requires reading the entire file and writing it again;  the faststart flag further increases I/O, as it moves the moov atom from the end to the beginning of the file, requiring a full file read and rewrite.

Using --no-hls-use-mpegts for live streams forces yt-dlp to write the stream directly to an MP4 container. This can be useful in scenarios with limited disk IOPS or to reduce wear on SSDs with a low Total Write Bytes (TWB) limit.
