### PR TITLE
Make Options extendable

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -11,6 +11,7 @@ use function array_values;
 use function in_array;
 use function str_contains;
 
+/** @phpstan-consistent-constructor */
 class Options
 {
     // @deprecated
@@ -250,7 +251,7 @@ class Options
      */
     private array $url = [];
 
-    private function __construct()
+    public function __construct()
     {
     }
 

--- a/tests/Fixtures/OptionsExtended.php
+++ b/tests/Fixtures/OptionsExtended.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YoutubeDl\Tests\Fixtures;
+
+final class OptionsExtended extends \YoutubeDl\Options
+{
+    // Preset Aliases
+    private ?string $presetAlias = null;
+
+    public function presetAlias(?string $presetAlias): self
+    {
+        $new = clone $this;
+        $new->presetAlias = $presetAlias;
+
+        return $new;
+    }
+
+    public function toArray(): array
+    {
+        $array = parent::toArray();
+
+        $array['preset-alias'] = $this->presetAlias;
+
+        return $array;
+    }
+}

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -72,4 +72,11 @@ final class OptionsTest extends TestCase
 
         Options::create()->output('/var/downloads');
     }
+
+    public function testExtendOutput(): void
+    {
+        $options = (new Fixtures\OptionsExtended())->toArray();
+
+        self::assertArrayHasKey('preset-alias', $options);
+    }
 }


### PR DESCRIPTION
Make Options Class extendable.
Had to raise min php version to 8.0 in composer to use static.
Private constructor removed as discussed.

Fixes https://github.com/norkunas/youtube-dl-php/issues/270