### PR TITLE
Add Option for disabling --ignore-config

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -72,6 +72,7 @@ class Options
 
     private ?string $downloadPath = null;
     private bool $cleanupMetadata = true;
+    private bool $ignoreConfig = true;
 
     // Network Options
     private ?string $proxy = null;
@@ -283,6 +284,19 @@ class Options
     public function getCleanupMetadata(): bool
     {
         return $this->cleanupMetadata;
+    }
+
+    public function ignoreConfig(bool $ignore): self
+    {
+        $new = clone $this;
+        $new->ignoreConfig = $ignore;
+
+        return $new;
+    }
+
+    public function getIgnoreConfig(): bool
+    {
+        return $this->ignoreConfig;
     }
 
     /**
@@ -1811,6 +1825,8 @@ class Options
     public function toArray(): array
     {
         return [
+            // General Options
+            'ignore-config' => $this->ignoreConfig,
             // Network Options
             'proxy' => $this->proxy,
             'socket-timeout' => $this->socketTimeout,

--- a/src/Options.php
+++ b/src/Options.php
@@ -1843,6 +1843,9 @@ class Options
     public function toArray(): array
     {
         return [
+            'ignore-config' => $this->ignoreConfig,
+            'ignore-errors' => true,
+            'write-info-json' => true,
             // Network Options
             'proxy' => $this->proxy,
             'socket-timeout' => $this->socketTimeout,
@@ -1987,7 +1990,6 @@ class Options
             'extractor-args' => $this->extractorArgs,
             'js-runtimes' => $this->jsRuntimes,
             'remote-components' => $this->remoteComponents,
-            'ignore-config' => $this->ignoreConfig,
 
             'url' => $this->url,
         ];

--- a/src/Options.php
+++ b/src/Options.php
@@ -73,6 +73,8 @@ class Options
     private ?string $downloadPath = null;
     private bool $cleanupMetadata = true;
     private bool $ignoreConfig = true;
+    private ?string $jsRuntimes = null;
+    private ?string $remoteComponents = null;
 
     // Network Options
     private ?string $proxy = null;
@@ -1799,6 +1801,22 @@ class Options
         return $new;
     }
 
+    public function jsRuntimes(string $jsRuntimes): self
+    {
+        $new = clone $this;
+        $new->jsRuntimes = $jsRuntimes;
+
+        return $new;
+    }
+
+    public function remoteComponents(?string $remoteComponents): self
+    {
+        $new = clone $this;
+        $new->remoteComponents = $remoteComponents;
+
+        return $new;
+    }
+
     /**
      * @param non-empty-string $url
      * @param non-empty-string ...$urls
@@ -1825,8 +1843,6 @@ class Options
     public function toArray(): array
     {
         return [
-            // General Options
-            'ignore-config' => $this->ignoreConfig,
             // Network Options
             'proxy' => $this->proxy,
             'socket-timeout' => $this->socketTimeout,
@@ -1969,6 +1985,9 @@ class Options
             'allow-dynamic-mpd' => $this->allowDynamicMpd,
             'hls-split-discontinuity' => $this->hlsSplitDiscontinuity,
             'extractor-args' => $this->extractorArgs,
+            'js-runtimes' => $this->jsRuntimes,
+            'remote-components' => $this->remoteComponents,
+            'ignore-config' => $this->ignoreConfig,
 
             'url' => $this->url,
         ];

--- a/src/YoutubeDl.php
+++ b/src/YoutubeDl.php
@@ -118,7 +118,6 @@ class YoutubeDl
         }
 
         $arguments = [
-            '--ignore-config',
             '--ignore-errors',
             '--write-info-json',
             ...ArgvBuilder::build($options),

--- a/src/YoutubeDl.php
+++ b/src/YoutubeDl.php
@@ -117,11 +117,7 @@ class YoutubeDl
             throw new NoDownloadPathProvidedException('Missing configured downloadPath option.');
         }
 
-        $arguments = [
-            '--ignore-errors',
-            '--write-info-json',
-            ...ArgvBuilder::build($options),
-        ];
+        $arguments = ArgvBuilder::build($options);
 
         $parsedData = [];
         $currentVideo = null;

--- a/tests/Process/ArgvBuilderTest.php
+++ b/tests/Process/ArgvBuilderTest.php
@@ -35,6 +35,9 @@ final class ArgvBuilderTest extends TestCase
             );
 
         self::assertSame([
+            '--ignore-config',
+            '--ignore-errors',
+            '--write-info-json',
             '--proxy=127.0.0.5',
             '--socket-timeout=5',
             '--playlist-items=1-3,7,10-13',

--- a/tests/Process/ArgvBuilderTest.php
+++ b/tests/Process/ArgvBuilderTest.php
@@ -50,4 +50,42 @@ final class ArgvBuilderTest extends TestCase
             'https://www.youtube.com/watch?v=Q-g_YNZ90tI',
         ], ArgvBuilder::build($options));
     }
+
+    public function testJsRuntimesArgument(): void
+    {
+        $options = Options::create()
+            ->downloadPath('/tmp')
+            ->jsRuntimes('deno,phantomjs')
+            ->url('https://example.com');
+
+        $argv = ArgvBuilder::build($options);
+
+        self::assertContains('--js-runtimes=deno,phantomjs', $argv);
+    }
+
+    public function testRemoteComponentsArgument(): void
+    {
+        $options = Options::create()
+            ->downloadPath('/tmp')
+            ->remoteComponents('default')
+            ->url('https://example.com');
+
+        $argv = ArgvBuilder::build($options);
+
+        self::assertContains('--remote-components=default', $argv);
+    }
+
+    public function testJsRuntimesAndRemoteComponentsNotPresentWhenNull(): void
+    {
+        $options = Options::create()
+            ->downloadPath('/tmp')
+            ->url('https://example.com');
+
+        $argv = ArgvBuilder::build($options);
+
+        foreach ($argv as $arg) {
+            self::assertStringNotContainsString('js-runtimes', $arg);
+            self::assertStringNotContainsString('remote-components', $arg);
+        }
+    }
 }


### PR DESCRIPTION
For some time now, an external JavaScript runtime has been required to download YouTube videos.
The JS runtime is intended to be defined via the configuration; however, the --ignore-config argument was set by default.

I added an option that allows --ignore-config to be ignored.

See: https://github.com/yt-dlp/yt-dlp/issues/15012