### PR TITLE
Fix thumbnail pattern string in listThumbnails

### DIFF
--- a/src/YoutubeDl.php
+++ b/src/YoutubeDl.php
@@ -217,7 +217,7 @@ class YoutubeDl
                 continue;
             }
 
-            if (str_starts_with($line, '[info] Thumbnails for')) {
+            if (str_starts_with($line, '[info] Available thumbnails for')) {
                 $parsing = 'table_header';
             } elseif ($parsing === 'table_header') {
                 $header = $line;

--- a/src/YoutubeDl.php
+++ b/src/YoutubeDl.php
@@ -217,7 +217,7 @@ class YoutubeDl
                 continue;
             }
 
-            if (preg_match('/^\[info\] (?:Available thumbnails|Thumbnails) for/', $line)) {
+            if (preg_match('/^\[info\] (?:Available thumbnails|Thumbnails) for/', $line) === 1) {
                 $parsing = 'table_header';
             } elseif ($parsing === 'table_header') {
                 $header = $line;

--- a/src/YoutubeDl.php
+++ b/src/YoutubeDl.php
@@ -217,7 +217,7 @@ class YoutubeDl
                 continue;
             }
 
-            if (str_starts_with($line, '[info] Available thumbnails for')) {
+            if (preg_match('/^\[info\] (?:Available thumbnails|Thumbnails) for/', $line)) {
                 $parsing = 'table_header';
             } elseif ($parsing === 'table_header') {
                 $header = $line;


### PR DESCRIPTION
Hello, thanks for your great package.

In newer versions of yt-dlp, the thumbnail title command has changed, and `listThumbnails` is no longer working. We should update it accordingly.

<img width="556" height="92" alt="image" src="https://github.com/user-attachments/assets/9f7f39cd-b24e-4774-9045-af5878db0f49" />
